### PR TITLE
Update MarkTeleport.scala

### DIFF
--- a/src/main/scala/cn/academy/vanilla/teleporter/skill/MarkTeleport.scala
+++ b/src/main/scala/cn/academy/vanilla/teleporter/skill/MarkTeleport.scala
@@ -77,7 +77,7 @@ class MTContext(p: EntityPlayer) extends Context(p, MarkTeleport) {
       val expincr: Float = 0.00018f * distance
       ctx.addSkillExp(expincr)
       player.fallDistance = 0
-      ctx.setCooldown(lerpf(30, 0, exp).toInt)
+      ctx.setCooldown(lerpf(30, 1, exp).toInt)
       TPSkillHelper.incrTPCount(player)
     }
     terminate()


### PR DESCRIPTION
I changed
ctx.setCooldown(lerpf(30, 0, exp).toInt)
to
ctx.setCooldown(lerpf(30, 1, exp).toInt)
to keep a little bit of cooldown on the skill, otherwise, there will always be the teleport "ghost" present, when you used the skill once.
This is more like a workaround.
I tried to compile a .jar myself to fix this on my server, but I did not manage to do it :-/