### PR TITLE
Modernize CraftTweaker support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,11 @@ repositories {
         name = "CoFH Maven"
         url = "http://maven.covers1624.net"
     }
+    maven {
+        // The main host of CraftTweaker related libs
+        name = "jared"
+        url = "http://maven.blamejared.com"
+    }
 }
 
 configurations {
@@ -95,6 +100,9 @@ dependencies {
     compile "codechicken:CodeChickenLib:1.12.2-${config.ccl_ver}:deobf"
     compile "codechicken:NotEnoughItems:1.12.2-${config.nei_ver}:deobf"
     deobfCompile "cofh:RedstoneFlux:1.12-2.0.0.1:universal"
+    deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.9.6"
+    deobfCompile "CraftTweaker2:CraftTweaker2-API:4.1.9.6"
+    deobfCompile "CraftTweaker2:ZenScript:4.1.9.6"
 }
 
 processResources {
@@ -117,11 +125,3 @@ processResources {
 }
 
 compileJava.options.encoding = "UTF-8"
-
-task getLibs << {
-    ant.mkdir(dir: 'libs')
-    ant.get(src: 'https://minecraft.curseforge.com/projects/crafttweaker/files/2452011/download',
-            dest: 'libs/CraftTweaker3-Dev-3.0.9C.jar', skipexisting: 'true')
-}
-
-sourceMainJava.dependsOn getLibs

--- a/src/main/java/cn/academy/support/minetweaker/ImagFusorSupport.java
+++ b/src/main/java/cn/academy/support/minetweaker/ImagFusorSupport.java
@@ -1,19 +1,20 @@
 package cn.academy.support.minetweaker;
 
+import cn.academy.crafting.ImagFusorRecipes;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import static cn.academy.crafting.ImagFusorRecipes.INSTANCE;
-import static cn.academy.support.minetweaker.MTSupport.toStack;
 /**
  * 
  * @author 3TUSK
  */
 @ZenClass("mods.academycraft.ImagFusor")
+@ZenRegister
 public class ImagFusorSupport {
 
     @ZenMethod
@@ -27,14 +28,14 @@ public class ImagFusorSupport {
         int liquidAmount;
         
         public AddImagFusorRecipe(IItemStack input, IItemStack output, int liquidAmount) {
-            this.input = toStack(input);
-            this.output = toStack(output);
+            this.input = MTSupport.toStack(input);
+            this.output = MTSupport.toStack(output);
             this.liquidAmount = liquidAmount;
         }
 
         @Override
         public void apply() {
-            INSTANCE.addRecipe(input, liquidAmount, output);
+            ImagFusorRecipes.INSTANCE.addRecipe(input, liquidAmount, output);
         }
 
         @Override

--- a/src/main/java/cn/academy/support/minetweaker/MTSupport.java
+++ b/src/main/java/cn/academy/support/minetweaker/MTSupport.java
@@ -1,32 +1,16 @@
 package cn.academy.support.minetweaker;
 
-import cn.academy.AcademyCraft;
-import cn.lambdalib2.registry.StateEventCallback;
-import crafttweaker.CraftTweakerAPI;
 import crafttweaker.api.item.IItemStack;
 import crafttweaker.api.minecraft.CraftTweakerMC;
-import net.minecraftforge.fml.common.Optional;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 
 /**
  * 
  * @author 3TUSK
  */
-public class MTSupport {
+public final class MTSupport {
 
-    private static final String MODID = "crafttweaker";
-
-    @StateEventCallback
-    @Optional.Method(modid=MODID)
-    private static void init(FMLInitializationEvent event) {
-        CraftTweakerAPI.registerClass(ImagFusorSupport.class);
-        CraftTweakerAPI.registerClass(MetalFormerSupport.class);
-        AcademyCraft.log.info("MineTweaker API support has been loaded.");
-    }
-
-    @Optional.Method(modid=MODID)
-    public static ItemStack toStack(IItemStack s) {
+    static ItemStack toStack(IItemStack s) {
         return CraftTweakerMC.getItemStack(s);
     }
 

--- a/src/main/java/cn/academy/support/minetweaker/MetalFormerSupport.java
+++ b/src/main/java/cn/academy/support/minetweaker/MetalFormerSupport.java
@@ -1,20 +1,21 @@
 package cn.academy.support.minetweaker;
 
 import cn.academy.block.tileentity.TileMetalFormer.Mode;
+import cn.academy.crafting.MetalFormerRecipes;
 import crafttweaker.CraftTweakerAPI;
 import crafttweaker.IAction;
+import crafttweaker.annotations.ZenRegister;
 import crafttweaker.api.item.IItemStack;
 import net.minecraft.item.ItemStack;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 
-import static cn.academy.crafting.MetalFormerRecipes.INSTANCE;
-import static cn.academy.support.minetweaker.MTSupport.toStack;
 /**
  * 
  * @author 3TUSK
  */
 @ZenClass("mods.academycraft.MetalFormer")
+@ZenRegister
 public class MetalFormerSupport {
     
     @ZenMethod
@@ -39,14 +40,14 @@ public class MetalFormerSupport {
         Mode mode;
         
         public AddMetalFormerRecipe(IItemStack input, IItemStack output, Mode mode) {
-            this.input = toStack(input);
-            this.output = toStack(output);
+            this.input = MTSupport.toStack(input);
+            this.output = MTSupport.toStack(output);
             this.mode = mode;
         }
         
         @Override
         public void apply() {
-            INSTANCE.add(input, output, mode);
+            MetalFormerRecipes.INSTANCE.add(input, output, mode);
         }
 
         @Override


### PR DESCRIPTION
This pull request:
1. Pull artifacts of CraftTweaker and its dependencies from a proper maven repo (`http://maven.blamejared.com` - the one that is owned by current maintainer of CraftTweaker (previously known as MineTweaker).
2. Use `@ZenRegister` for automated ZenClass registration (handled on CraftTweaker's end). CraftTweaker also has a `@ModOnly` annotation; however, as we ship native support for CraftTweaker, using `@ModOnly` is kinda redundant, so it's not used in this PR.
3. `MTSupport` is now only a holder of utility methods that are only used by CraftTweaker supports. Class-loading should not be an issue, as they will remain untouched if CraftTweaker is absent (akin to that of JEI).