### PR TITLE
Added timeout to IP-address retrieval in order to prevent hang and disconnect

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# These are supported funding model platforms
+
+# github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: WeAthFolD
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# custom: # Replace with a single custom sponsorship URL

--- a/src/main/java/cn/academy/analytic/AnalyticDataListener.java
+++ b/src/main/java/cn/academy/analytic/AnalyticDataListener.java
@@ -166,6 +166,7 @@ public class AnalyticDataListener {
             URL object = new URL("https://myip.ipip.net");
             HttpURLConnection con = (HttpURLConnection)object.openConnection();
             con.setRequestProperty("User-Agent","");
+            con.setConnectTimeout(5000);
             BufferedReader br = new BufferedReader(new InputStreamReader(con.getInputStream(), StandardCharsets.UTF_8));
             String line = null;
             StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
Greetings,
Since about a week, sometimes everyone logging into my server experiences a total game freeze after about 10 seconds in game. The freeze lasts for about a minute, after which they disconnect. I have pinpointed the probable cause to #813 , I can see the same message about https://myip.ipip.net in my server log the moment it hangs (and only then). 

The suggested workaround in that issue (disabling my internet) is not possible for me, since there are also other services running on the same node which require the internet. This is also not a real fix.

My suggestion is adding a timeout of say 5 seconds to the connection attempt, this should prevent Minecraft from freezing up. Ideally this connection should of course be done asynchronously, but this quick fix should suffice for now.

This is my first time contributing on GitHub (I normally use GitLab) so please tell me if I need to improve something.

Thank you for considering, have a nice day!